### PR TITLE
Fixed incorrect named subpattern syntax in preg_match

### DIFF
--- a/code/dataobjects/AdImpression.php
+++ b/code/dataobjects/AdImpression.php
@@ -105,8 +105,8 @@ function get_browser_info()
     
     // finally get the correct version number
     $known = array('Version', $ub, 'other');
-    $pattern = '#(?<browser>' . join('|', $known) .
-    ')[/ ]+(?<version>[0-9.|a-zA-Z.]*)#';
+    $pattern = '#(?P<browser>' . join('|', $known) .
+    ')[/ ]+(?P<version>[0-9.|a-zA-Z.]*)#';
     if (!preg_match_all($pattern, $u_agent, $matches)) {
         // we have no matching number just continue
     }


### PR DESCRIPTION
The following pattern:

```
$pattern = '#(?<browser>' . join('|', $known) .
')[/ ]+(?<version>[0-9.|a-zA-Z.]*)#';
```

Should be:

```
$pattern = '#(?P<browser>' . join('|', $known) .
')[/ ]+(?P<version>[0-9.|a-zA-Z.]*)#';
```
